### PR TITLE
Remove pre-commit task

### DIFF
--- a/tasks/index.js
+++ b/tasks/index.js
@@ -49,7 +49,6 @@ module.exports = {
     'self:json': [require('./self/json')],
     'self': [sequence('self:jshint', 'self:jscs', 'self:jsvalidate', 'self:json')],
 
-    'pre-commit': [['lint']],
     'bump': [require('./bump')],
     'watch': [require('./watch')],
     'serve': [['browser-sync', 'watch']],


### PR DESCRIPTION
There are issues with this, like this repo trying to lint itself (and gulp not being a dependency).

Some theme repos may not be at a stage where it can pass linting for each commit. We keep the guppy package dependency, but leave it to the theme to make use of it if it wants.