### PR TITLE
Increase maxBuffer for lint:scss

### DIFF
--- a/tasks/lint/scss.js
+++ b/tasks/lint/scss.js
@@ -20,6 +20,7 @@ module.exports = function () {
     return gulp
         .src(config.src.css)
         .pipe(scsslint({
-            'config': lintFile
+            'config': lintFile,
+            'maxBuffer': 1048576
         }));
 };


### PR DESCRIPTION
For projects which have a LOT of SCSS issues to address.

Bumping the [maxBuffer](https://github.com/juanfran/gulp-scss-lint#maxbuffer) allows all of the issues to be listed, without projects having to jump through hoops to bump this buffer level themselves.

1048576 = 1024 * 1024