### PR TITLE
Allow `dep:install` to fail silently if no `bower.json` exists. Fixes…

### DIFF
--- a/tasks/dependencies/install.js
+++ b/tasks/dependencies/install.js
@@ -1,7 +1,13 @@
 'use strict';
 
-var bower = require('gulp-bower');
+var bower = require('gulp-bower'),
+    fs = require('fs');
 
 module.exports = function () {
+
+    if (false === fs.existsSync('../../bower.json')) {
+        return;
+    }
+
     return bower();
 };


### PR DESCRIPTION
… #42