### PR TITLE
New: Add support for adding style notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ toolkit.extendTasks(gulp, { /* Task Overrides */ });
 
 Once your `Gulpfile.js` is in place, install all the dependencies using `yarn install`. If you're not already using Yarn, please see the [installation instructions](https://yarnpkg.com/lang/en/docs/install/).
 
+See the files in the example directory for more advanced configuration.
+
 ## Tasks
 
 Once installed, the following tasks will be available to run via `gulp <taskname>`.
@@ -70,11 +72,11 @@ Once installed, the following tasks will be available to run via `gulp <taskname
 * `gulp build` makes sure all dependencies (Bower components) are installed, and then runs through all of the individual build tasks.
 * `gulp build:css` compiles SCSS into CSS.
 * `gulp build:rtl` generates an RTL stylesheet in the theme root.
-* `gulp build:js` concatenates Javascript files defined in `config.js` and outputs into our theme `/js/` directory.
+* `gulp build:js` concatenates JavaScript files defined in `config.js` and outputs into our theme `/js/` directory.
 * `gulp build:images` optimizes all of our images stored in `/develop/images/` to `/images/`.
 * `gulp build:i18n` generates a translations file at `/develop/languages/textdomain.pot`, where textdomain is the theme package name within `package.json`.
 * `gulp build:styleguide` uses our SCSS files to generate a live style guide at `/develop/styleguide/` using Cortana (some setup required).
-* `gulp build:potomo` converts and `.po` files within `develop/languages/` into `.mo` files within `/languages/`.
+* `gulp build:potomo` converts and `.po` files within `/develop/languages/` into `.mo` files within `/languages/`.
 
 ### Clean
 Clean tasks are included so you can quickly remove any compiled assets, for example using `gulp clean:bowerjs` will delete the concatenated `vendor.js` and `vendor.min.js` we have built from Bower Components. Tasks available are:

--- a/example/Gulpfile.js
+++ b/example/Gulpfile.js
@@ -6,7 +6,7 @@ var gulp = require('gulp'),
 
 toolkit.extendConfig({
     theme: {
-        name: 'Your Theme',
+        name: pkg.theme.name,
         themeuri: pkg.homepage,
         description: pkg.theme.description,
         author: pkg.author,
@@ -17,7 +17,8 @@ toolkit.extendConfig({
         tags: pkg.theme.tags,
         textdomain: pkg.name
         domainpath: pkg.theme.domainpath
-        template: 'genesis'
+        template: 'genesis',
+        notes: pkg.theme.notes
     },
     dest: {
         bowerjs: 'develop/vendor/',

--- a/example/package.json
+++ b/example/package.json
@@ -10,5 +10,14 @@
   "dependencies": {
     "gulp": "^3.9.1",
     "gulp-wp-toolkit": "^1.0.1"
-  }
+  },
+  "theme": {
+    "name": "Your Theme Name",
+    "description": "Your theme description.",
+    "tags": "white, one-column, two-columns, fixed-width, custom-menu, full-width-template, sticky-post, theme-options, threaded-comments, rtl-language-support, translation-ready",
+    "license": "GPL-2.0+",
+    "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
+    "domainpath": "/languages",
+    "notes": "This is a section for notes.\nIt can be on multiple lines by using \\n instead of real line breaks."
+  },
 }

--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -44,8 +44,12 @@ module.exports = function() {
         // If a value has been set in config.theme.???, ...
         if ( config.theme[themeHeaderArr[key]] ) {
             // Then build the file header for it.
-            themeHeader += key + ': ' + config.theme[themeHeaderArr[key]]+ '\n';
+            themeHeader += key + ': ' + config.theme[themeHeaderArr[key]] + '\n';
         }
+    }
+
+    if ( config.theme.notes ) {
+        themeHeader += '\n' + config.theme.notes;
     }
 
     // Remove final new line character.


### PR DESCRIPTION
Style notes, if defined, will appear in the `style.css` file header, underneath the standard tags. This is a good spot to add in credits to other projects upon which a theme is based i.e. _s, Bootstrap, etc.