### PR TITLE
SCSS stylelint task should use the `stylelint-config-wordpress` SCSS config

### DIFF
--- a/lintfiles/.stylelintscssrc
+++ b/lintfiles/.stylelintscssrc
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-wordpress/scss"
+}

--- a/tasks/lint/stylelint-scss.js
+++ b/tasks/lint/stylelint-scss.js
@@ -11,7 +11,7 @@ module.exports = function () {
     const themeLintFile = config.lintfiles.stylelint;
     let lintFile;
 
-    lintFile = path.join(__dirname, '../../lintfiles/', '.stylelintrc');
+    lintFile = path.join(__dirname, '../../lintfiles/', '.stylelintscssrc');
 
     if (fs.existsSync(themeLintFile)) {
         lintFile = themeLintFile;


### PR DESCRIPTION
Follow up to #60 #62