### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[lintfiles/php*.xml]
+indent_style = tab
+indent_size = 4
+
+[example/Gulpfile.js]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/example/Gulpfile.js
+++ b/example/Gulpfile.js
@@ -1,113 +1,113 @@
 /* eslint-disable */
 'use strict';
 
-const gulp    = require( 'gulp' ),
-      pkg     = require( './package.json' ),
-      toolkit = require( 'gulp-wp-toolkit' );
+const gulp = require('gulp'),
+	pkg = require('./package.json'),
+	toolkit = require('gulp-wp-toolkit');
 
 toolkit.extendConfig({
-    theme: {
-        name: pkg.theme.name,
-        themeuri: pkg.homepage,
-        description: pkg.theme.description,
-        author: pkg.author,
-        authoruri: pkg.theme.authoruri,
-        version: pkg.version,
-        license: pkg.license,
-        licenseuri: pkg.theme.licenseuri,
-        tags: pkg.theme.tags,
-        textdomain: pkg.name,
-        domainpath: pkg.theme.domainpath,
-        template: 'genesis',
-        notes: pkg.theme.notes
-    },
-    js: {
-        'letters' : [
-           'develop/js/a.js',
-           'develop/js/b.js',
-           'develop/js/c.js'
-       ],
-       'numbers' : [
-           'develop/js/1.js',
-           'develop/js/2.js'
-       ],
-       'standalone' : [
-           'develop/js/standalone.js'
-       ]
-    },
-    server: {
-        url: 'example.dev'
-    },
-    src: {
-      zipuser: [
-        'images/*',
-        'includes/**/*',
-        'includes-vendors/**/*',
-        'js/*',
-        'languages/*',
-        'front-page.php',
-        'functions.php',
-        'LICENSE.md',
-        'page_landing.php',
-        'readme.txt',
-        'screenshot.png',
-        'style*'
-      ],
-      zipdev: [
-        'develop/images/*',
-        'develop/js/*',
-        'develop/languages/*',
-        'develop/scss/**/*',
-        'images/*',
-        'includes/**/*',
-        'includes-vendors/**/*',
-        'js/*',
-        'languages/*',
-        'CHANGELOG.md',
-        'composer.json',
-        'composer.lock',
-        'front-page.php',
-        'functions.php',
-        'Gulpfile.js',
-        'LICENSE.md',
-        'package.json',
-        'page_landing.php',
-        'readme.txt',
-        'README.md',
-        'screenshot.png',
-        'style*'
-      ]
-    },
-    css: {
-        baseFontSize: 16, // Used by postcss-pxtorem.
-        scss: {
-            'editor-style': {
-                src: 'develop/scss/editor.scss',
-                dest: './',
-                outputStyle: 'compressed',
-            }
-        }
-    }
+	theme: {
+		name: pkg.theme.name,
+		themeuri: pkg.homepage,
+		description: pkg.theme.description,
+		author: pkg.author,
+		authoruri: pkg.theme.authoruri,
+		version: pkg.version,
+		license: pkg.license,
+		licenseuri: pkg.theme.licenseuri,
+		tags: pkg.theme.tags,
+		textdomain: pkg.name,
+		domainpath: pkg.theme.domainpath,
+		template: 'genesis',
+		notes: pkg.theme.notes,
+	},
+	js: {
+		'letters': [
+			'develop/js/a.js',
+			'develop/js/b.js',
+			'develop/js/c.js',
+		],
+		'numbers': [
+			'develop/js/1.js',
+			'develop/js/2.js',
+		],
+		'standalone': [
+			'develop/js/standalone.js',
+		],
+	},
+	server: {
+		url: 'example.dev',
+	},
+	src: {
+		zipuser: [
+			'images/*',
+			'includes/**/*',
+			'includes-vendors/**/*',
+			'js/*',
+			'languages/*',
+			'front-page.php',
+			'functions.php',
+			'LICENSE.md',
+			'page_landing.php',
+			'readme.txt',
+			'screenshot.png',
+			'style*',
+		],
+		zipdev: [
+			'develop/images/*',
+			'develop/js/*',
+			'develop/languages/*',
+			'develop/scss/**/*',
+			'images/*',
+			'includes/**/*',
+			'includes-vendors/**/*',
+			'js/*',
+			'languages/*',
+			'CHANGELOG.md',
+			'composer.json',
+			'composer.lock',
+			'front-page.php',
+			'functions.php',
+			'Gulpfile.js',
+			'LICENSE.md',
+			'package.json',
+			'page_landing.php',
+			'readme.txt',
+			'README.md',
+			'screenshot.png',
+			'style*',
+		],
+	},
+	css: {
+		baseFontSize: 16, // Used by postcss-pxtorem.
+		scss: {
+			'editor-style': {
+				src: 'develop/scss/editor.scss',
+				dest: './',
+				outputStyle: 'compressed',
+			},
+		},
+	},
 });
 
 toolkit.extendTasks(gulp, {
-    // Task Name.
-    console: [
-        ['build'],
-        function () {
-            console.log('This is an extended task. It depends on `build`');
-        }
-    ],
-    'lint:php': [['lint:phpcs']], // How not to run lint:phpmd.
-    'zip': [[ 'zipuser', 'zipdev' ]],
-    'zipuser': function() {
-      return gulp.src( toolkit.config.src.zipuser, { base: './' } )
-        .pipe( zip( pkg.name + '-' + pkg.version + '.zip' ) )
-        .pipe( gulp.dest( 'dist' ) );
-    },
-    'zipdev': function() {
-      return gulp.src( toolkit.config.src.zipdev, { base: './' } )
-        .pipe( zip( pkg.name + '-developer-' + pkg.version + '.zip' ) )
-        .pipe( gulp.dest( 'dist' ) );
-    }
+	// Task Name.
+	console: [
+		['build'],
+		function() {
+			console.log('This is an extended task. It depends on `build`');
+		},
+	],
+	'lint:php': [['lint:phpcs']], // How not to run lint:phpmd.
+	'zip': [['zipuser', 'zipdev']],
+	'zipuser': function() {
+		return gulp.src(toolkit.config.src.zipuser, {base: './'}).
+			pipe(zip(pkg.name + '-' + pkg.version + '.zip')).
+			pipe(gulp.dest('dist'));
+	},
+	'zipdev': function() {
+		return gulp.src(toolkit.config.src.zipdev, {base: './'}).
+			pipe(zip(pkg.name + '-developer-' + pkg.version + '.zip')).
+			pipe(gulp.dest('dist'));
+	},
 });

--- a/lintfiles/.eslintrc
+++ b/lintfiles/.eslintrc
@@ -1,3 +1,3 @@
 {
-  extends: 'wordpress'
+  "extends": "wordpress"
 }

--- a/lintfiles/phpcs.xml
+++ b/lintfiles/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="WordPress Theme">
-    <description>PHPCS Ruleset for a WordPress Theme</description>
-    <rule ref="WordPress">
-        <exclude name="WordPress.VIP"/>
-    </rule>
+	<description>PHPCS Ruleset for a WordPress Theme</description>
+	<rule ref="WordPress">
+		<exclude name="WordPress.VIP"/>
+	</rule>
 </ruleset>

--- a/lintfiles/phpmd.xml
+++ b/lintfiles/phpmd.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0"?>
 <ruleset name="phpmd.xml"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
-    <description>PHPMD Ruleset for a WordPress Theme</description>
-    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
-    <rule ref="rulesets/cleancode.xml/ElseExpression"/>
-    <rule ref="rulesets/cleancode.xml/StaticAccess"/>
-    <!-- Temporarily disabled as PHPMD seems to have a bug for this rule -->
-    <!-- <rule ref="rulesets/cleancode.xml/NestedScopes" /> -->
-    <rule ref="rulesets/codesize.xml/CyclomaticComplexity"/>
-    <rule ref="rulesets/codesize.xml/NPathComplexity"/>
-    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/>
-    <rule ref="rulesets/codesize.xml/ExcessiveClassLength"/>
-    <rule ref="rulesets/codesize.xml/ExcessiveParameterList"/>
-    <rule ref="rulesets/codesize.xml/ExcessivePublicCount"/>
-    <rule ref="rulesets/codesize.xml/TooManyFields"/>
-    <rule ref="rulesets/codesize.xml/TooManyMethods"/>
-    <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity"/>
-    <!-- Too controversial! -->
-    <!-- <rule ref="rulesets/controversial.xml/Superglobals" /> -->
-    <rule ref="rulesets/design.xml/ExitExpression"/>
-    <rule ref="rulesets/design.xml/EvalExpression"/>
-    <rule ref="rulesets/design.xml/GotoStatement"/>
-    <rule ref="rulesets/design.xml/NumberOfChildren"/>
-    <rule ref="rulesets/design.xml/DepthOfInheritance"/>
-    <rule ref="rulesets/design.xml/CouplingBetweenObjects"/>
-    <rule ref="rulesets/naming.xml/ShortVariable"/>
-    <rule ref="rulesets/naming.xml/LongVariable">
-        <properties>
-            <property name="maximum" value="35"/>
-        </properties>
-    </rule>
-    <rule ref="rulesets/naming.xml/ShortMethodName">
-        <properties>
-            <property name="minimum" value="2"/>
-        </properties>
-    </rule>
-    <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
-    <rule ref="rulesets/naming.xml/ConstantNamingConventions"/>
-    <rule ref="rulesets/naming.xml/BooleanGetMethodName"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
+		 xmlns="http://pmd.sf.net/ruleset/1.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+		 xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+	<description>PHPMD Ruleset for a WordPress Theme</description>
+	<rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
+	<rule ref="rulesets/cleancode.xml/ElseExpression"/>
+	<rule ref="rulesets/cleancode.xml/StaticAccess"/>
+	<!-- Temporarily disabled as PHPMD seems to have a bug for this rule -->
+	<!-- <rule ref="rulesets/cleancode.xml/NestedScopes" /> -->
+	<rule ref="rulesets/codesize.xml/CyclomaticComplexity"/>
+	<rule ref="rulesets/codesize.xml/NPathComplexity"/>
+	<rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/>
+	<rule ref="rulesets/codesize.xml/ExcessiveClassLength"/>
+	<rule ref="rulesets/codesize.xml/ExcessiveParameterList"/>
+	<rule ref="rulesets/codesize.xml/ExcessivePublicCount"/>
+	<rule ref="rulesets/codesize.xml/TooManyFields"/>
+	<rule ref="rulesets/codesize.xml/TooManyMethods"/>
+	<rule ref="rulesets/codesize.xml/ExcessiveClassComplexity"/>
+	<!-- Too controversial! -->
+	<!-- <rule ref="rulesets/controversial.xml/Superglobals" /> -->
+	<rule ref="rulesets/design.xml/ExitExpression"/>
+	<rule ref="rulesets/design.xml/EvalExpression"/>
+	<rule ref="rulesets/design.xml/GotoStatement"/>
+	<rule ref="rulesets/design.xml/NumberOfChildren"/>
+	<rule ref="rulesets/design.xml/DepthOfInheritance"/>
+	<rule ref="rulesets/design.xml/CouplingBetweenObjects"/>
+	<rule ref="rulesets/naming.xml/ShortVariable"/>
+	<rule ref="rulesets/naming.xml/LongVariable">
+		<properties>
+			<property name="maximum" value="35"/>
+		</properties>
+	</rule>
+	<rule ref="rulesets/naming.xml/ShortMethodName">
+		<properties>
+			<property name="minimum" value="2"/>
+		</properties>
+	</rule>
+	<rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
+	<rule ref="rulesets/naming.xml/ConstantNamingConventions"/>
+	<rule ref="rulesets/naming.xml/BooleanGetMethodName"/>
+	<rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
+	<rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
+	<rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
+	<rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
 </ruleset>

--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const bs     = require( 'browser-sync' ).create( 'SIM01' ),
-      config = require( '../config' );
+const bs = require('browser-sync').create('SIM01'),
+  config = require('../config');
 
 module.exports = function() {
-    bs.init({
-        proxy: config.server.url,
-        online: true
-    });
+  bs.init({
+    proxy: config.server.url,
+    online: true,
+  });
 };

--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -1,123 +1,124 @@
 'use strict';
 
-const gulp       = require( 'gulp' ),
-      config     = require( '../../config' ),
-      plumber    = require( 'gulp-plumber' ),
-      sourcemap  = require( 'gulp-sourcemaps' ),
-      sass       = require( 'gulp-sass' ),
-      normalize  = require( 'node-normalize-scss' ).includePaths,
-      postcss    = require( 'gulp-postcss' ),
-      bulksass   = require( 'gulp-sass-bulk-import' ),
-      mqpacker   = require( 'css-mqpacker' ),
-      autoprefix = require( 'autoprefixer' ),
-      pxtorem    = require( 'postcss-pxtorem' ),
-      cssnano    = require( 'cssnano' ),
-      banner     = require( 'postcss-banner' ),
-      notify     = require( 'gulp-notify' ),
-      map        = require( 'lodash.map' ),
-      rename     = require( 'gulp-rename' ),
-      fs         = require( 'fs' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  plumber = require('gulp-plumber'),
+  sourcemap = require('gulp-sourcemaps'),
+  sass = require('gulp-sass'),
+  normalize = require('node-normalize-scss').includePaths,
+  postcss = require('gulp-postcss'),
+  bulksass = require('gulp-sass-bulk-import'),
+  mqpacker = require('css-mqpacker'),
+  autoprefix = require('autoprefixer'),
+  pxtorem = require('postcss-pxtorem'),
+  cssnano = require('cssnano'),
+  banner = require('postcss-banner'),
+  notify = require('gulp-notify'),
+  map = require('lodash.map'),
+  rename = require('gulp-rename'),
+  fs = require('fs');
 
 module.exports = function() {
 
-	const buildThemeHeader = function() {
-		let key;
-		let themeHeader      = '';
-		const themeHeaderArr = {
-			// 'Header Name': 'Key under config.theme',
-			'Theme Name': 'name',
-			'Theme URI': 'themeuri',
-			Author: 'author',
-			'Author URI': 'authoruri',
-			Description: 'description',
-			Version: 'version',
-			Status: 'status',
-			License: 'license',
-			'License URI': 'licenseuri',
-			Tags: 'tags',
-			'Text Domain': 'textdomain',
-			'Domain Path': 'domainpath',
-			Template: 'template'
-		};
+  const buildThemeHeader = function() {
+    const themeHeaderArr = {
+      // 'Header Name': 'Key under config.theme',
+      'Theme Name': 'name',
+      'Theme URI': 'themeuri',
+      Author: 'author',
+      'Author URI': 'authoruri',
+      Description: 'description',
+      Version: 'version',
+      Status: 'status',
+      License: 'license',
+      'License URI': 'licenseuri',
+      Tags: 'tags',
+      'Text Domain': 'textdomain',
+      'Domain Path': 'domainpath',
+      Template: 'template',
+    };
 
-		// Loop through above object properties.
-		for ( key in themeHeaderArr ) {
-			// If a value has been set in config.theme.???, ...
-			if ( config.theme[ themeHeaderArr[ key ] ] ) {
-				// Then build the file header for it.
-				themeHeader += key + ': ' + config.theme[ themeHeaderArr[ key ] ] + '\n';
-			}
-		}
+    let key;
+    let themeHeader = '';
 
-		if ( config.theme.notes ) {
-			themeHeader += '\n' + config.theme.notes;
-		}
+    // Loop through above object properties.
+    for (key in themeHeaderArr) {
+      // If a value has been set in config.theme.???, ...
+      if (config.theme[themeHeaderArr[key]]) {
+        // Then build the file header for it.
+        themeHeader += key + ': ' + config.theme[themeHeaderArr[key]] + '\n';
+      }
+    }
 
-		// Remove final new line character.
-		themeHeader = themeHeader.slice( 0, - 1 );
+    if (config.theme.notes) {
+      themeHeader += '\n' + config.theme.notes;
+    }
 
-		return themeHeader;
-	};
+    // Remove final new line character.
+    themeHeader = themeHeader.slice(0, -1);
 
-	const getPostProcessors = function( outputConfig, outputFilename ) {
+    return themeHeader;
+  };
 
-		let themeHeader;
-		const postProcessors = [
-			mqpacker(
-				{
-					sort: true
-				}
-			),
-			autoprefix(),
-			pxtorem(
-				{
-					root_value: config.css.basefontsize,
-					replace: false,
-					media_query: true
-				}
-			),
-		];
+  const getPostProcessors = function(outputConfig, outputFilename) {
 
-		// Add CSS Nano to further compress our output..
-		if ( 'compressed' === outputConfig.outputStyle ) {
-			postProcessors.push( cssnano() );
-		}
-
-		// If we're working on the main style.css, output the theme header.
-		if ( 'style' === outputFilename ) {
-			themeHeader = buildThemeHeader();
-			postProcessors.push(
-				banner(
-					{
-						banner: themeHeader
-					}
-                )
-            );
-		}
-
-		return postProcessors;
-
-	};
-
-	return map(config.css.scss, function(outputConfig, outputFilename) {
-
-        if (!fs.existsSync(outputConfig.src)) {
-            return console.log('ERROR >> Source file ' + outputConfig.src + ' was not found.');
+    let themeHeader;
+    const postProcessors = [
+      mqpacker(
+        {
+          sort: true,
         }
+      ),
+      autoprefix(),
+      pxtorem(
+        {
+          root_value: config.css.basefontsize,
+          replace: false,
+          media_query: true,
+        }
+      ),
+    ];
 
-        return gulp
-        .src(outputConfig.src)
-        .pipe(bulksass())
-        .pipe(plumber())
-        .pipe(rename(outputFilename + '.css'))
-        .pipe(sourcemap.init())
-        .pipe(sass.sync({
-            outputStyle: outputConfig.outputStyle,
-            includePaths: [].concat(normalize)
-        }))
-        .pipe(postcss(getPostProcessors(outputConfig, outputFilename)))
-        .pipe(sourcemap.write('./'))
-        .pipe(gulp.dest(outputConfig.dest))
-        .pipe(notify({message: config.messages.css}));
-    });
+    // Add CSS Nano to further compress our output..
+    if ('compressed' === outputConfig.outputStyle) {
+      postProcessors.push(cssnano());
+    }
+
+    // If we're working on the main style.css, output the theme header.
+    if ('style' === outputFilename) {
+      themeHeader = buildThemeHeader();
+      postProcessors.push(
+        banner(
+          {
+            banner: themeHeader,
+          }
+        )
+      );
+    }
+
+    return postProcessors;
+
+  };
+
+  return map(config.css.scss, function(outputConfig, outputFilename) {
+
+    if (!fs.existsSync(outputConfig.src)) {
+      return console.log('ERROR >> Source file ' + outputConfig.src +
+        ' was not found.');
+    }
+
+    return gulp.src(outputConfig.src)
+      .pipe(bulksass())
+      .pipe(plumber())
+      .pipe(rename(outputFilename + '.css'))
+      .pipe(sourcemap.init())
+      .pipe(sass.sync({
+        outputStyle: outputConfig.outputStyle,
+        includePaths: [].concat(normalize),
+      }))
+      .pipe(postcss(getPostProcessors(outputConfig, outputFilename)))
+      .pipe(sourcemap.write('./'))
+      .pipe(gulp.dest(outputConfig.dest))
+      .pipe(notify({message: config.messages.css}));
+  });
 };

--- a/tasks/build/i18n.js
+++ b/tasks/build/i18n.js
@@ -1,21 +1,20 @@
 'use strict';
 
-const gulp    = require( 'gulp' ),
-      config  = require( '../../config' ),
-      sort    = require( 'gulp-sort' ),
-      plumber = require( 'gulp-plumber' ),
-      potgen  = require( 'gulp-wp-pot' ),
-      notify  = require( 'gulp-notify' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  sort = require('gulp-sort'),
+  plumber = require('gulp-plumber'),
+  potgen = require('gulp-wp-pot'),
+  notify = require('gulp-notify');
 
-module.exports = function () {
-    return gulp
-        .src(config.src.php)
-        .pipe(plumber())
-        .pipe(sort())
-        .pipe(potgen({
-            domain: config.theme.textdomain,
-            package: config.theme.name + ' ' + config.theme.version
-        }))
-        .pipe(gulp.dest(config.dest.i18npo + config.theme.textdomain + '.pot'))
-        .pipe(notify({message: config.messages.i18n}));
+module.exports = function() {
+  return gulp.src(config.src.php)
+    .pipe(plumber())
+    .pipe(sort())
+    .pipe(potgen({
+      domain: config.theme.textdomain,
+      package: config.theme.name + ' ' + config.theme.version,
+    }))
+    .pipe(gulp.dest(config.dest.i18npo + config.theme.textdomain + '.pot'))
+    .pipe(notify({message: config.messages.i18n}));
 };

--- a/tasks/build/images.js
+++ b/tasks/build/images.js
@@ -1,17 +1,17 @@
 'use strict';
 
-const gulp     = require( 'gulp' ),
-      config   = require( '../../config' ),
-      changed  = require( 'gulp-changed' ),
-      cache    = require( 'gulp-cache' ),
-      imagemin = require( 'gulp-imagemin' ),
-      notify   = require( 'gulp-notify' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  changed = require('gulp-changed'),
+  cache = require('gulp-cache'),
+  imagemin = require('gulp-imagemin'),
+  notify = require('gulp-notify');
 
-module.exports = function () {
-    return gulp
-        .src(config.src.images)
-        .pipe(changed(config.dest.images))
-        .pipe(cache(imagemin({optimizationLevel: 3, progressive: true, interlaced: true})))
-        .pipe(gulp.dest(config.dest.images))
-        .pipe(notify({message: config.messages.images}));
+module.exports = function() {
+  return gulp.src(config.src.images)
+    .pipe(changed(config.dest.images))
+    .pipe(cache(
+      imagemin({optimizationLevel: 3, progressive: true, interlaced: true})))
+    .pipe(gulp.dest(config.dest.images))
+    .pipe(notify({message: config.messages.images}));
 };

--- a/tasks/build/js.js
+++ b/tasks/build/js.js
@@ -1,24 +1,23 @@
 'use strict';
 
-const gulp    = require( 'gulp' ),
-      config  = require( '../../config' ),
-      concat  = require( 'gulp-concat' ),
-      plumber = require( 'gulp-plumber' ),
-      uglify  = require( 'gulp-uglify' ),
-      rename  = require( 'gulp-rename' ),
-      notify  = require( 'gulp-notify' ),
-      map     = require( 'lodash.map' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  concat = require('gulp-concat'),
+  plumber = require('gulp-plumber'),
+  uglify = require('gulp-uglify'),
+  rename = require('gulp-rename'),
+  notify = require('gulp-notify'),
+  map = require('lodash.map');
 
-module.exports = function () {
-    return map(config.js, function(files, filename) {
-        return gulp
-            .src(files)
-            .pipe(plumber())
-            .pipe(concat(filename + '.js'))
-            .pipe(gulp.dest(config.dest.js))
-            .pipe(uglify())
-            .pipe(rename(filename + '.min.js'))
-            .pipe(gulp.dest(config.dest.js))
-            .pipe(notify({message: config.messages.js}));
-    });
+module.exports = function() {
+  return map(config.js, function(files, filename) {
+    return gulp.src(files)
+      .pipe(plumber())
+      .pipe(concat(filename + '.js'))
+      .pipe(gulp.dest(config.dest.js))
+      .pipe(uglify())
+      .pipe(rename(filename + '.min.js'))
+      .pipe(gulp.dest(config.dest.js))
+      .pipe(notify({message: config.messages.js}));
+  });
 };

--- a/tasks/build/potomo.js
+++ b/tasks/build/potomo.js
@@ -1,14 +1,13 @@
 'use strict';
 
-const gulp   = require( 'gulp' ),
-      config = require( '../../config' ),
-      potomo = require( 'gulp-potomo' ),
-      notify = require( 'gulp-notify' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  potomo = require('gulp-potomo'),
+  notify = require('gulp-notify');
 
-module.exports = function () {
-    return gulp
-        .src([config.src.i18n + '*.po'])
-        .pipe(potomo())
-        .pipe(gulp.dest(config.dest.i18nmo))
-        .pipe(notify({message: config.messages.potomo}));
+module.exports = function() {
+  return gulp.src([config.src.i18n + '*.po'])
+    .pipe(potomo())
+    .pipe(gulp.dest(config.dest.i18nmo))
+    .pipe(notify({message: config.messages.potomo}));
 };

--- a/tasks/build/rtl.js
+++ b/tasks/build/rtl.js
@@ -1,15 +1,15 @@
 'use strict';
 
-const gulp    = require( 'gulp' ),
-      config  = require( '../../config' ),
-      rtlcss  = require( 'gulp-rtlcss' ),
-      rename  = require( 'gulp-rename' ),
-      replace = require( 'gulp-replace' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  rtlcss = require('gulp-rtlcss'),
+  rename = require('gulp-rename'),
+  replace = require('gulp-replace');
 
-module.exports = function () {
-    return gulp.src('style.css')
-        .pipe(rtlcss())
-        .pipe(rename('rtl.css'))
-        .pipe(replace(/\/\*#\ssourceMappingURL(.+)$/gm, ''))
-        .pipe(gulp.dest(config.dest.css));
+module.exports = function() {
+  return gulp.src('style.css')
+    .pipe(rtlcss())
+    .pipe(rename('rtl.css'))
+    .pipe(replace(/\/\*#\ssourceMappingURL(.+)$/gm, ''))
+    .pipe(gulp.dest(config.dest.css));
 };

--- a/tasks/build/styleguide.js
+++ b/tasks/build/styleguide.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const gulp     = require( 'gulp' ),
-      config   = require( '../../config' ),
-      hologram = require( 'gulp-hologram' ),
-      notify   = require( 'gulp-notify' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  hologram = require('gulp-hologram'),
+  notify = require('gulp-notify');
 
-module.exports = function () {
-    return gulp
-        .src(config.hologram.config)
-        .pipe(hologram({logging:true}))
-        .pipe(notify({message: config.messages.styleguide}));
+module.exports = function() {
+  return gulp.src(config.hologram.config)
+    .pipe(hologram({logging: true}))
+    .pipe(notify({message: config.messages.styleguide}));
 };

--- a/tasks/bump.js
+++ b/tasks/bump.js
@@ -1,24 +1,24 @@
 'use strict';
 
-const gulp   = require( 'gulp' ),
-      config = require( '../config' ),
-      bump   = require( 'gulp-bump' ),
-      args   = require( 'yargs' ).argv;
+const gulp = require('gulp'),
+  config = require('../config'),
+  bump = require('gulp-bump'),
+  args = require('yargs').argv;
 
 module.exports = function() {
 
-    const type    = args.type,
-          version = args.version;
-    let options   = {};
+  const type = args.type,
+    version = args.version;
 
-    if (version) {
-        options.version = version;
-    } else {
-        options.type = type;
-    }
+  let options = {};
 
-    return gulp
-        .src(config.bump.files)
-        .pipe(bump(options))
-        .pipe(gulp.dest('./'));
+  if (version) {
+    options.version = version;
+  } else {
+    options.type = type;
+  }
+
+  return gulp.src(config.bump.files)
+    .pipe(bump(options))
+    .pipe(gulp.dest('./'));
 };

--- a/tasks/clean/css.js
+++ b/tasks/clean/css.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const config = require( '../../config' ),
-      del    = require( 'del' );
+const config = require('../../config'),
+  del = require('del');
 
-module.exports = function () {
-    return del([
-        config.dest.css + '*.css',
-        config.dest.css + '*.css.map'
-    ], {force: true});
+module.exports = function() {
+  return del([
+    config.dest.css + '*.css',
+    config.dest.css + '*.css.map',
+  ], {force: true});
 };

--- a/tasks/clean/i18n.js
+++ b/tasks/clean/i18n.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const config = require( '../../config' ),
-      del    = require( 'del' );
+const config = require('../../config'),
+  del = require('del');
 
-module.exports = function () {
-    return del([
-        config.dest.i18npo + config.theme.textdomain + '.pot',
-        config.dest.i18nmo
-    ], {force: true});
+module.exports = function() {
+  return del([
+    config.dest.i18npo + config.theme.textdomain + '.pot',
+    config.dest.i18nmo,
+  ], {force: true});
 };

--- a/tasks/clean/images.js
+++ b/tasks/clean/images.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const config = require( '../../config' ),
-      del    = require( 'del' );
+const config = require('../../config'),
+  del = require('del');
 
 module.exports = function () {
     return del([

--- a/tasks/clean/js.js
+++ b/tasks/clean/js.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const config = require( '../../config' ),
-      del    = require( 'del' );
+const config = require('../../config'),
+  del = require('del');
 
-module.exports = function () {
-    return del([
-        config.dest.js + config.js.filename + '.js',
-        config.dest.js + config.js.filename + '.min.js'
-    ], {force: true});
+module.exports = function() {
+  return del([
+    config.dest.js + config.js.filename + '.js',
+    config.dest.js + config.js.filename + '.min.js',
+  ], {force: true});
 };

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -4,44 +4,43 @@ const sequence = require('gulp-sequence');
 
 module.exports = {
 
-    'browser-sync': [require('./browser-sync')],
+  'browser-sync': [require('./browser-sync')],
 
-    'build:css': [require('./build/css')],
-    'build:rtl': [require('./build/rtl')],
-    'build:js': [require('./build/js')],
-    'build:images': [require('./build/images')],
-    'build:i18n:potgen': [require('./build/i18n')],
-    'build:i18n:potomo': [require('./build/potomo')],
-    'build:i18n': [['build:i18n:potgen','build:i18n:potomo']],
-    'build': [['build:css', 'build:js', 'build:images', 'build:i18n']],
-    'build:styleguide': [require('./build/styleguide')],
+  'build:css': [require('./build/css')],
+  'build:rtl': [require('./build/rtl')],
+  'build:js': [require('./build/js')],
+  'build:images': [require('./build/images')],
+  'build:i18n:potgen': [require('./build/i18n')],
+  'build:i18n:potomo': [require('./build/potomo')],
+  'build:i18n': [['build:i18n:potgen', 'build:i18n:potomo']],
+  'build': [['build:css', 'build:js', 'build:images', 'build:i18n']],
+  'build:styleguide': [require('./build/styleguide')],
 
-    'clean:css': [require('./clean/css')],
-    'clean:js': [require('./clean/js')],
-    'clean:images': [require('./clean/images')],
-    'clean:i18n': [require('./clean/i18n')],
-    'clean': [['clean:css', 'clean:js', 'clean:images', 'clean:i18n']],
+  'clean:css': [require('./clean/css')],
+  'clean:js': [require('./clean/js')],
+  'clean:images': [require('./clean/images')],
+  'clean:i18n': [require('./clean/i18n')],
+  'clean': [['clean:css', 'clean:js', 'clean:images', 'clean:i18n']],
 
-    'lint:scss': [require( './lint/stylelint-scss')],
-    'lint:css': [require( './lint/stylelint-css')],
-    'lint:colors': [require('./lint/colors')],
-    'lint:style': [sequence('lint:scss', 'lint:css', 'lint:colors')],
+  'lint:scss': [require('./lint/stylelint-scss')],
+  'lint:css': [require('./lint/stylelint-css')],
+  'lint:colors': [require('./lint/colors')],
+  'lint:style': [sequence('lint:scss', 'lint:css', 'lint:colors')],
 
-    'lint:json': [require('./lint/json')],
-    'lint:jsvalidate': [require('./lint/jsvalidate')],
-    'lint:eslint': [require('./lint/eslint')],
-    'lint:js': [sequence('lint:jsvalidate', 'lint:json', 'lint:eslint')],
+  'lint:json': [require('./lint/json')],
+  'lint:jsvalidate': [require('./lint/jsvalidate')],
+  'lint:eslint': [require('./lint/eslint')],
+  'lint:js': [sequence('lint:jsvalidate', 'lint:json', 'lint:eslint')],
 
-    'lint:phpcs': [require('./lint/phpcs')],
-    'lint:phpmd': [require('./lint/phpmd')],
-    'lint:php': [sequence('lint:phpcs', 'lint:phpmd')],
+  'lint:phpcs': [require('./lint/phpcs')],
+  'lint:phpmd': [require('./lint/phpmd')],
+  'lint:php': [sequence('lint:phpcs', 'lint:phpmd')],
 
+  'lint': [sequence('lint:style', 'lint:php', 'lint:js')],
 
-    'lint': [sequence('lint:style', 'lint:php', 'lint:js')],
-
-    'bump': [require('./bump')],
-    'watch': [require('./watch')],
-    'serve': [['browser-sync', 'watch']],
-    'default': [['build', 'browser-sync', 'watch']]
+  'bump': [require('./bump')],
+  'watch': [require('./watch')],
+  'serve': [['browser-sync', 'watch']],
+  'default': [['build', 'browser-sync', 'watch']],
 
 };

--- a/tasks/lint/colors.js
+++ b/tasks/lint/colors.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const gulp       = require( 'gulp' ),
-      config     = require( '../../config' ),
-      postcss    = require( 'gulp-postcss' ),
-      colorguard = require( 'colorguard' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  postcss = require('gulp-postcss'),
+  colorguard = require('colorguard');
 
-module.exports = function () {
-    return gulp
-        .src(config.src.css)
-        .pipe(postcss([colorguard()]));
+module.exports = function() {
+  return gulp.src(config.src.css)
+    .pipe(postcss([colorguard()]));
 };

--- a/tasks/lint/eslint.js
+++ b/tasks/lint/eslint.js
@@ -1,26 +1,24 @@
 'use strict';
 
-const gulp   = require( 'gulp' ),
-      config = require( '../../config' ),
-      fs     = require( 'fs' ),
-      path   = require( 'path' ),
-      eslint = require( 'gulp-eslint' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  fs = require('fs'),
+  path = require('path'),
+  eslint = require('gulp-eslint');
 
-module.exports = function () {
+module.exports = function() {
 
-    const themeLintFile = config.lintfiles.eslint;
-    let lintFile;
+  const themeLintFile = config.lintfiles.eslint;
 
-    lintFile = path.join(__dirname, '../../lintfiles/', '.eslintrc');
+  let lintFile = path.join(__dirname, '../../lintfiles/', '.eslintrc');
 
-    if (fs.existsSync(themeLintFile)) {
-        lintFile = themeLintFile;
-    }
+  if (fs.existsSync(themeLintFile)) {
+    lintFile = themeLintFile;
+  }
 
-    return gulp
-        .src(config.src.js)
-        .pipe(eslint({
-            configFile: lintFile
-        }))
-        .pipe(eslint.format());
+  return gulp.src(config.src.js)
+    .pipe(eslint({
+      configFile: lintFile,
+    }))
+    .pipe(eslint.format());
 };

--- a/tasks/lint/json.js
+++ b/tasks/lint/json.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const gulp     = require( 'gulp' ),
-      config   = require( '../../config' ),
-      jsonlint = require( 'gulp-jsonlint' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  jsonlint = require('gulp-jsonlint');
 
-module.exports = function () {
-    return gulp
-        .src(config.src.json)
-        .pipe(jsonlint());
+module.exports = function() {
+  return gulp.src(config.src.json)
+    .pipe(jsonlint());
 };

--- a/tasks/lint/jsvalidate.js
+++ b/tasks/lint/jsvalidate.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const gulp       = require( 'gulp' ),
-      config     = require( '../../config' ),
-      jsvalidate = require( 'gulp-jsvalidate' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  jsvalidate = require('gulp-jsvalidate');
 
-module.exports = function () {
-    return gulp
-        .src(config.src.js)
-        .pipe(jsvalidate());
+module.exports = function() {
+  return gulp.src(config.src.js)
+    .pipe(jsvalidate());
 };

--- a/tasks/lint/phpcs.js
+++ b/tasks/lint/phpcs.js
@@ -1,31 +1,30 @@
 'use strict';
 
-const gulp   = require( 'gulp' ),
-      config = require( '../../config' ),
-      fs     = require( 'fs' ),
-      path   = require( 'path' ),
-      phpcs  = require( 'gulp-phpcs' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  fs = require('fs'),
+  path = require('path'),
+  phpcs = require('gulp-phpcs');
 
-module.exports = function () {
+module.exports = function() {
 
-    const themeConfigFile = config.lintfiles.phpcs;
-    let configFile;
+  const themeConfigFile = config.lintfiles.phpcs;
+  let configFile;
 
-    configFile = path.join(__dirname, '../../lintfiles/', 'phpcs.xml');
+  configFile = path.join(__dirname, '../../lintfiles/', 'phpcs.xml');
 
-    if (fs.existsSync(themeConfigFile)) {
-        configFile = themeConfigFile;
-    }
+  if (fs.existsSync(themeConfigFile)) {
+    configFile = themeConfigFile;
+  }
 
-    if (fs.existsSync(themeConfigFile + '.dist')) {
-        configFile = themeConfigFile + '.dist';
-    }
+  if (fs.existsSync(themeConfigFile + '.dist')) {
+    configFile = themeConfigFile + '.dist';
+  }
 
-    return gulp
-        .src(config.src.php)
-        .pipe(phpcs({
-            standard: configFile,
-            warningSeverity: 0
-        }))
-        .pipe(phpcs.reporter('log'));
+  return gulp.src(config.src.php)
+    .pipe(phpcs({
+      standard: configFile,
+      warningSeverity: 0,
+    }))
+    .pipe(phpcs.reporter('log'));
 };

--- a/tasks/lint/phpmd.js
+++ b/tasks/lint/phpmd.js
@@ -1,31 +1,29 @@
 'use strict';
 
-const gulp   = require( 'gulp' ),
-      config = require( '../../config' ),
-      fs     = require( 'fs' ),
-      path   = require( 'path' ),
-      phpmd  = require( 'gulp-phpmd-plugin' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  fs = require('fs'),
+  path = require('path'),
+  phpmd = require('gulp-phpmd-plugin');
 
-module.exports = function () {
+module.exports = function() {
 
-    const themeConfigFile = config.lintfiles.phpmd;
-    let configFile;
+  const themeConfigFile = config.lintfiles.phpmd;
 
-    configFile = path.join(__dirname, '../../lintfiles/', 'phpmd.xml');
+  let configFile = path.join(__dirname, '../../lintfiles/', 'phpmd.xml');
 
-    if (fs.existsSync(themeConfigFile)) {
-        configFile = themeConfigFile;
-    }
+  if (fs.existsSync(themeConfigFile)) {
+    configFile = themeConfigFile;
+  }
 
-    if (fs.existsSync(themeConfigFile + '.dist')) {
-        configFile = themeConfigFile + '.dist';
-    }
+  if (fs.existsSync(themeConfigFile + '.dist')) {
+    configFile = themeConfigFile + '.dist';
+  }
 
-    return gulp
-        .src(config.src.php)
-        .pipe(phpmd({
-            format: 'text',
-            ruleset: configFile
-        }))
-        .pipe(phpmd.reporter('log'));
+  return gulp.src(config.src.php)
+    .pipe(phpmd({
+      format: 'text',
+      ruleset: configFile,
+    }))
+    .pipe(phpmd.reporter('log'));
 };

--- a/tasks/lint/stylelint-css.js
+++ b/tasks/lint/stylelint-css.js
@@ -1,28 +1,26 @@
 'use strict';
 
-const gulp      = require( 'gulp' ),
-      config    = require( '../../config' ),
-      fs        = require( 'fs' ),
-      path      = require( 'path' ),
-      stylelint = require( 'gulp-stylelint' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  fs = require('fs'),
+  path = require('path'),
+  stylelint = require('gulp-stylelint');
 
-module.exports = function () {
+module.exports = function() {
 
-    const themeLintFile = config.lintfiles.stylelint;
-    let lintFile;
+  const themeLintFile = config.lintfiles.stylelint;
 
-    lintFile = path.join(__dirname, '../../lintfiles/', '.stylelintrc');
+  let lintFile = path.join(__dirname, '../../lintfiles/', '.stylelintrc');
 
-    if (fs.existsSync(themeLintFile)) {
-        lintFile = themeLintFile;
-    }
+  if (fs.existsSync(themeLintFile)) {
+    lintFile = themeLintFile;
+  }
 
-    return gulp
-        .src(config.src.css)
-        .pipe(stylelint({
-            configFile: lintFile,
-            reporters: [
-                {formatter: 'string', console: true}
-            ]
-        }));
+  return gulp.src(config.src.css)
+    .pipe(stylelint({
+      configFile: lintFile,
+      reporters: [
+        {formatter: 'string', console: true},
+      ],
+    }));
 };

--- a/tasks/lint/stylelint-scss.js
+++ b/tasks/lint/stylelint-scss.js
@@ -1,28 +1,26 @@
 'use strict';
 
-const gulp      = require( 'gulp' ),
-      config    = require( '../../config' ),
-      fs        = require( 'fs' ),
-      path      = require( 'path' ),
-      stylelint = require( 'gulp-stylelint' );
+const gulp = require('gulp'),
+  config = require('../../config'),
+  fs = require('fs'),
+  path = require('path'),
+  stylelint = require('gulp-stylelint');
 
-module.exports = function () {
+module.exports = function() {
 
-    const themeLintFile = config.lintfiles.stylelint;
-    let lintFile;
+  const themeLintFile = config.lintfiles.stylelint;
 
-    lintFile = path.join(__dirname, '../../lintfiles/', '.stylelintscssrc');
+  let lintFile = path.join(__dirname, '../../lintfiles/', '.stylelintscssrc');
 
-    if (fs.existsSync(themeLintFile)) {
-        lintFile = themeLintFile;
-    }
+  if (fs.existsSync(themeLintFile)) {
+    lintFile = themeLintFile;
+  }
 
-    return gulp
-        .src(config.src.scss)
-        .pipe(stylelint({
-            configFile: lintFile,
-            reporters: [
-                {formatter: 'string', console: true}
-            ]
-        }));
+  return gulp.src(config.src.scss)
+    .pipe(stylelint({
+      configFile: lintFile,
+      reporters: [
+        {formatter: 'string', console: true},
+      ],
+    }));
 };

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -1,18 +1,18 @@
 'use strict';
 
-const gulp   = require( 'gulp' ),
-      config = require( '../config' ),
-      bs     = require( 'browser-sync' ).get( 'SIM01' );
+const gulp = require('gulp'),
+  config = require('../config'),
+  bs = require('browser-sync').get('SIM01');
 
 module.exports = function() {
-    gulp.watch(config.src.scss, ['build:css']);
-    gulp.watch(config.src.js, ['build:js']);
-    gulp.watch(config.src.images, ['build:images']);
-    gulp.watch(config.src.php, ['build:i18n']);
-    gulp.watch([
-        config.src.css,
-        config.src.js,
-        config.src.images,
-        config.src.php
-    ]).on('change', bs.reload);
+  gulp.watch(config.src.scss, ['build:css']);
+  gulp.watch(config.src.js, ['build:js']);
+  gulp.watch(config.src.images, ['build:images']);
+  gulp.watch(config.src.php, ['build:i18n']);
+  gulp.watch([
+    config.src.css,
+    config.src.js,
+    config.src.images,
+    config.src.php,
+  ]).on('change', bs.reload);
 };

--- a/utils/extend-config.js
+++ b/utils/extend-config.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const merge         = require( 'lodash.merge' ),
-      defaultConfig = require( '../config' );
+const merge = require('lodash.merge'),
+  defaultConfig = require('../config');
 
 module.exports = function extendConfig(config) {
-    merge(defaultConfig, config);
+  merge(defaultConfig, config);
 };

--- a/utils/extend-tasks.js
+++ b/utils/extend-tasks.js
@@ -3,10 +3,10 @@
 const defaultTasks = require('../tasks');
 
 module.exports = function extendTasks(gulp, tasks) {
-    tasks = Object.assign({}, defaultTasks, tasks);
+  tasks = Object.assign({}, defaultTasks, tasks);
 
-    Object.keys(tasks).forEach(function(taskName) {
-        const args = [taskName].concat(tasks[taskName]);
-        gulp.task.apply(gulp, args);
-    });
+  Object.keys(tasks).forEach(function(taskName) {
+    const args = [taskName].concat(tasks[taskName]);
+    gulp.task.apply(gulp, args);
+  });
 };


### PR DESCRIPTION
The first commit adds the config.

The second commit is auto applying PHPStorm's formatting, using the `editorconfig`, and then re-adjusting a few bits back to preferred formatting (like putting the `.` before `pipe` and not at the end of the previous line) and a couple of other changes.

To ignore whitespace-only changes, see https://github.com/craigsimps/gulp-wp-toolkit/pull/65/files?w=1