### PR TITLE
Add filename to `gulp-notify` messages

### DIFF
--- a/config.js
+++ b/config.js
@@ -30,10 +30,10 @@ module.exports = {
       ]
     },
     messages: {
-        css: 'Stylesheet compiled and saved.',
+        css: 'Stylesheet compiled and saved: <%= file.relative %>',
         i18n: 'Translation file generated.',
-        images: 'Image files compressed and copied.',
-        js: 'JavaScript task complete.',
+        images: 'Image files compressed and copied: <%= file.relative %>',
+        js: 'JavaScript task complete: <%= file.relative %>',
         potomo: 'PO files converted to MO files.',
         styleguide: 'Styleguide task complete.'
     },


### PR DESCRIPTION
## Description
Gives a more verbose notification message by adding the filename of the generated file. For example, during an SCSS compile we will see: `Stylesheet compiled and saved: style.css`

## Motivation and Context
Fixes #57 and adds similar output for images and JavaScript files.

## How Has This Been Tested?
Implemented within local branch where several stylesheets are compiled. The output is shown to be:
```
[17:19:05] gulp-notify: [Gulp notification] Stylesheet compiled and saved: edd.css.map
[17:19:05] gulp-notify: [Gulp notification] Stylesheet compiled and saved: style.css.map
[17:19:06] gulp-notify: [Gulp notification] Stylesheet compiled and saved: edd.css
[17:19:06] gulp-notify: [Gulp notification] Stylesheet compiled and saved: style.css
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project (I've run `npm run lint`).
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
