### PR TITLE
Allow config override for PostCSS `pxtorem`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add a `package.json` to your theme like so:
   "main": "Gulpfile.js",
   "devDependencies": {
     "gulp": "^3.9.1",
-    "gulp-wp-toolkit": "^1.0.1"
+    "gulp-wp-toolkit": "^2"
   }
 }
 ```

--- a/config.js
+++ b/config.js
@@ -42,6 +42,8 @@ module.exports = {
     },
     css: {
         basefontsize: 16,
+        remreplace: false,
+        remmediaquery: true,
         scss: {
             'style': {
                 src: 'develop/scss/style.scss',

--- a/example/Gulpfile.js
+++ b/example/Gulpfile.js
@@ -79,7 +79,9 @@ toolkit.extendConfig({
 		],
 	},
 	css: {
-		baseFontSize: 16, // Used by postcss-pxtorem.
+		basefontsize: 16, // Used by postcss-pxtorem.
+        remreplace: false, // Used by postcss-pxtorem.
+        remmediaquery: true, // Used by postcss-pxtorem.
 		scss: {
 			'editor-style': {
 				src: 'develop/scss/editor.scss',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gulp-wp-toolkit",
   "homepage": "https://github.com/craigsimps/gulp-wp-toolkit",
   "author": "Craig Simpson <craig@craigsimpson.scot>",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Set of configurable Gulp tasks for use in my WordPress themes.",
   "repository": "https://github.com/craigsimps/gulp-wp-toolkit.git",
   "license": "MIT",

--- a/tasks/build/css.js
+++ b/tasks/build/css.js
@@ -73,8 +73,8 @@ module.exports = function() {
       pxtorem(
         {
           root_value: config.css.basefontsize,
-          replace: false,
-          media_query: true,
+          replace: config.css.remreplace,
+          media_query: config.css.remmediaquery,
         }
       ),
     ];


### PR DESCRIPTION
Moves the configuration used by the PostCSS [pxtorem](https://github.com/cuth/postcss-pxtorem) package to our global `config.js` file, so that consuming themes can optionally switch off media query conversion to REMs, and can also optionally turn on the replacement of pixel values with REMs.

## Description
Replaced hard coded config values in `css.js` with config values in `config.js`.

## Motivation and Context
A package user requested this change so they could turn off the media query REM conversions. cc @timothyjensen

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project (I've run `npm run lint`).
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
