### PR TITLE
Update to use Node v8.0.0 (current) for Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   yarn: true
 language: node_js
 node_js:
-  - "6"
+  - "8"
 before_install: yarn global add greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
Recent dependency updates (Stylelint) require Node version 8, meaning our current Travis CI pipeline failed on commit because it was set to use version 6.

## Description
Update version of Node specified in .travis.yml from 6 to 8.

## Motivation and Context
Allows Travis CI tests to run.

## How Has This Been Tested?
Committed to `develop` branch, watched Travis CI build complete.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project (I've run `npm run lint`).
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
