### PR TITLE
Remove server config mapping to allow full BrowserSync config

### DIFF
--- a/config.js
+++ b/config.js
@@ -55,6 +55,5 @@ module.exports = {
         }
     },
     js: {},
-    theme: {},
-    server: {},
+    theme: {}
 };

--- a/config.js
+++ b/config.js
@@ -55,5 +55,6 @@ module.exports = {
         }
     },
     js: {},
-    theme: {}
+    theme: {},
+    server: {},
 };

--- a/example/Gulpfile.js
+++ b/example/Gulpfile.js
@@ -37,6 +37,7 @@ toolkit.extendConfig({
 	},
 	server: {
 		proxy: 'example.dev',
+        online: true,
 	},
 	src: {
 		zipuser: [

--- a/example/Gulpfile.js
+++ b/example/Gulpfile.js
@@ -36,7 +36,7 @@ toolkit.extendConfig({
 		],
 	},
 	server: {
-		url: 'example.dev',
+		proxy: 'example.dev',
 	},
 	src: {
 		zipuser: [

--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -5,9 +5,6 @@ const bs = require('browser-sync').create('SIM01'),
 
 module.exports = function() {
   if (config.server.url) {
-    bs.init({
-      proxy: config.server.url,
-      online: true,
-    });
+    bs.init( config.server );
   }
 };

--- a/tasks/browser-sync.js
+++ b/tasks/browser-sync.js
@@ -4,7 +4,7 @@ const bs = require('browser-sync').create('SIM01'),
   config = require('../config');
 
 module.exports = function() {
-  if (config.server.url) {
+  if (config.server) {
     bs.init( config.server );
   }
 };


### PR DESCRIPTION
Remove server config mapping to allow full control over the BrowserSync config.

## Description

Simplify BrowserSync init task.

## Motivation and Context

Add support for HTTPS. Fixes #102

## How Has This Been Tested?

Tested successfully with the following config in Gulpfile.js:

```js
server: {
    proxy: "https://genesis-starter.test",
    port: "8000",
    https: {
        "key": "/Users/seothemes/.valet/Certificates/genesis-starter.test.key",
        "cert": "/Users/seothemes/.valet/Certificates/genesis-starter.test.crt"
    }
}
```

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project (I've run `npm run lint`).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
